### PR TITLE
Drop '-template' from x-temp snippet's type declaration

### DIFF
--- a/x-template.sublime-snippet
+++ b/x-template.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-  <content><![CDATA[<script type="text/x-handlebars-template" data-template-name="$1">
+  <content><![CDATA[<script type="text/x-handlebars" data-template-name="$1">
     $0
 </script>]]></content>
   <tabTrigger>x-temp</tabTrigger>


### PR DESCRIPTION
I believe that 'text/x-handlebars-template' is only used in the case of
defining templates that do not make use of the 'data-template-name' attribute.
