### PR TITLE
Fix syntax highlighting of unquoted attributes.

### DIFF
--- a/Handlebars.JSON-tmLanguage
+++ b/Handlebars.JSON-tmLanguage
@@ -635,7 +635,7 @@
                 }
             ], 
             "name": "entity.other.attribute-name.html", 
-            "end": "(?<='|\")" 
+            "end": "(?<='|\"|)"
         }, 
         "tag_id_attribute": {
             "begin": "\\b(id)\\b\\s*(=)", 
@@ -647,7 +647,7 @@
                     "name": "punctuation.separator.key-value.html"
                 }
             }, 
-            "end": "(?<='|\")", 
+            "end": "(?<='|\"|)",
             "name": "meta.attribute-with-value.id.html", 
             "patterns": [
                 {

--- a/Handlebars.tmLanguage
+++ b/Handlebars.tmLanguage
@@ -997,7 +997,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?&lt;='|")</string>
+			<string>(?&lt;='|"|)</string>
 			<key>name</key>
 			<string>entity.other.attribute-name.html</string>
 			<key>patterns</key>
@@ -1030,7 +1030,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?&lt;='|")</string>
+			<string>(?&lt;='|"|)</string>
 			<key>name</key>
 			<string>meta.attribute-with-value.id.html</string>
 			<key>patterns</key>


### PR DESCRIPTION
Fixes #29.

Thanks to: https://sublimetext.userecho.com/topic/106859-syntax-highlighting-for-html5-unquoted-attribute-value-syntax/
