### PR TITLE
Allow an optional leading `@` in variable names.

### DIFF
--- a/Handlebars.JSON-tmLanguage
+++ b/Handlebars.JSON-tmLanguage
@@ -434,7 +434,7 @@
             ]
         }, 
         "block_helper": {
-            "begin": "(\\{\\{\\#)([-a-zA-Z0-9_\\./]+)\\s+([-a-zA-Z0-9_\\./]+)*", 
+            "begin": "(\\{\\{\\#)([-a-zA-Z0-9_\\./]+)\\s+(@?[-a-zA-Z0-9_\\./]+)*",
             "end": "(\\}\\})", 
             "name": "meta.function.block.start.handlebars", 
             "endCaptures": {
@@ -495,7 +495,7 @@
             ]
         }, 
         "partial_and_var": {
-            "begin": "(\\{\\{\\{*>*)\\s*([-a-zA-Z0-9_\\./]+)*", 
+            "begin": "(\\{\\{\\{*>*)\\s*(@?[-a-zA-Z0-9_\\./]+)*",
             "end": "(\\}\\}\\}*)", 
             "name": "meta.function.inline.other.handlebars", 
             "endCaptures": {

--- a/Handlebars.tmLanguage
+++ b/Handlebars.tmLanguage
@@ -114,7 +114,7 @@
 		<key>block_helper</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{\{\#)([-a-zA-Z0-9_\./]+)\s+([-a-zA-Z0-9_\./]+)*</string>
+			<string>(\{\{\#)([-a-zA-Z0-9_\./]+)\s+(@?[-a-zA-Z0-9_\./]+)*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -823,7 +823,7 @@
 		<key>partial_and_var</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{\{\{*&gt;*)\s*([-a-zA-Z0-9_\./]+)*</string>
+			<string>(\{\{\{*&gt;*)\s*(@?[-a-zA-Z0-9_\./]+)*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Fixes #31.

The tests [here](https://github.com/daaain/Handlebars/blob/b1191c7d04854d24a74e68aacdc928a95a410212/test/inline_script.html#L44-L50) seems to work fine with this change.
