### PR TITLE
Add highlighting for whitespace control syntax.

### DIFF
--- a/Handlebars.JSON-tmLanguage
+++ b/Handlebars.JSON-tmLanguage
@@ -312,8 +312,8 @@
             ]
         }, 
         "end_block": {
-            "begin": "(\\{\\{/)([a-zA-Z0-9_\\.-]+)\\s*", 
-            "end": "(\\}\\})", 
+            "begin": "(\\{\\{~?/)([a-zA-Z0-9_\\.-]+)\\s*",
+            "end": "(~?\\}\\})",
             "name": "meta.function.block.end.handlebars", 
             "endCaptures": {
                 "1": {
@@ -433,8 +433,8 @@
             ]
         }, 
         "block_helper": {
-            "begin": "(\\{\\{\\#)([-a-zA-Z0-9_\\./]+)\\s+(@?[-a-zA-Z0-9_\\./]+)*",
-            "end": "(\\}\\})", 
+            "begin": "(\\{\\{~?\\#)([-a-zA-Z0-9_\\./]+)\\s+(@?[-a-zA-Z0-9_\\./]+)*",
+            "end": "(~?\\}\\})",
             "name": "meta.function.block.start.handlebars", 
             "endCaptures": {
                 "1": {
@@ -494,8 +494,8 @@
             ]
         }, 
         "partial_and_var": {
-            "begin": "(\\{\\{\\{*>*)\\s*(@?[-a-zA-Z0-9_\\./]+)*",
-            "end": "(\\}\\}\\}*)", 
+            "begin": "(\\{\\{~?\\{*>*)\\s*(@?[-a-zA-Z0-9_\\./]+)*",
+            "end": "(~?\\}\\}\\}*)",
             "name": "meta.function.inline.other.handlebars", 
             "endCaptures": {
                 "1": {

--- a/Handlebars.tmLanguage
+++ b/Handlebars.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -110,7 +110,7 @@
 		<key>block_helper</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{\{\#)([-a-zA-Z0-9_\./]+)\s+(@?[-a-zA-Z0-9_\./]+)*</string>
+			<string>(\{\{~?\#)([-a-zA-Z0-9_\./]+)\s+(@?[-a-zA-Z0-9_\./]+)*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -130,7 +130,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\}\})</string>
+			<string>(~?\}\})</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -208,7 +208,7 @@
 		<key>end_block</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{\{/)([a-zA-Z0-9_\.-]+)\s*</string>
+			<string>(\{\{~?/)([a-zA-Z0-9_\.-]+)\s*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -223,7 +223,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\}\})</string>
+			<string>(~?\}\})</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -235,7 +235,8 @@
 			<key>name</key>
 			<string>meta.function.block.end.handlebars</string>
 			<key>patterns</key>
-			<array/>
+			<array>
+			</array>
 		</dict>
 		<key>entities</key>
 		<dict>
@@ -818,7 +819,7 @@
 		<key>partial_and_var</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{\{\{*&gt;*)\s*(@?[-a-zA-Z0-9_\./]+)*</string>
+			<string>(\{\{~?\{*&gt;*)\s*(@?[-a-zA-Z0-9_\./]+)*</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -833,7 +834,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\}\}\}*)</string>
+			<string>(~?\}\}\}*)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Fixes #26.

I added support for optional `~` after `{{` and before `}}`, in all but comment blocks. Please try it out before merging.
