### PR TITLE
Add support for Handlebars inline with attributes

### DIFF
--- a/Handlebars.JSON-tmLanguage
+++ b/Handlebars.JSON-tmLanguage
@@ -670,6 +670,21 @@
                 }, 
                 {
                     "include": "#string-single-quoted"
+                }, 
+                {
+                    "include": "#block_comments"
+                }, 
+                {
+                    "include": "#comments"
+                }, 
+                {
+                    "include": "#block_helper"
+                }, 
+                {
+                    "include": "#end_block"
+                }, 
+                {
+                    "include": "#partial_and_var"
                 }
             ]
         }

--- a/Handlebars.tmLanguage
+++ b/Handlebars.tmLanguage
@@ -973,6 +973,26 @@
 					<key>include</key>
 					<string>#string-single-quoted</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#block_comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#block_helper</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#end_block</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#partial_and_var</string>
+				</dict>
 			</array>
 		</dict>
 		<key>tag_generic_attribute</key>

--- a/test/template.handlebars
+++ b/test/template.handlebars
@@ -33,5 +33,5 @@
 <!-- {{! <h2 class="{{class}}">Test</h2> }} -->
 {{/if}}
 
-{{! TODO: inline attributes }}
+{{! inline attributes }}
 <input type="checkbox" id="medication_taken" {{#if medication_taken}}checked{{/if}}>


### PR DESCRIPTION
I did some more tweaking on the language support. I think I've got support for Handlebars inline with HTML attributes going. I updated both the XML and JSON files this time. Again, please double check the JSON.
