### PR TITLE
Recognize escaped quote characters in strings

### DIFF
--- a/Handlebars.JSON-tmLanguage
+++ b/Handlebars.JSON-tmLanguage
@@ -52,10 +52,7 @@
                             "include": "#tag-generic-attribute"
                         }, 
                         {
-                            "include": "#string-double-quoted"
-                        }, 
-                        {
-                            "include": "#string-single-quoted"
+                            "include": "#string"
                         }
                     ]
                 }, 
@@ -454,10 +451,7 @@
             }, 
             "patterns": [
                 {
-                    "include": "#string-single-quoted"
-                }, 
-                {
-                    "include": "#string-double-quoted"
+                    "include": "#string"
                 }
             ]
         }, 
@@ -477,6 +471,9 @@
             }, 
             "patterns": [
                 {
+                    "include": "#escaped-single-quote"
+                },
+                {
                     "include": "#block_comments"
                 }, 
                 {
@@ -493,15 +490,28 @@
                 }
             ]
         }, 
+        "string": {
+            "patterns": [
+                {
+                    "include": "#string-single-quoted"
+                },
+                {
+                    "include": "#string-double-quoted"
+                }
+            ]
+        },
+        "escaped-single-quote": {
+            "name": "constant.character.escape.js",
+            "match": "\\\\'"
+        },
+        "escaped-double-quote": {
+            "name": "constant.character.escape.js",
+            "match": "\\\\\""
+        },
         "partial_and_var": {
             "begin": "(\\{\\{~?\\{*(>|!<)*)\\s*(@?[-a-zA-Z0-9_\\./]+)*",
             "end": "(~?\\}\\}\\}*)",
             "name": "meta.function.inline.other.handlebars", 
-            "endCaptures": {
-                "1": {
-                    "name": "support.constant.handlebars"
-                }
-            }, 
             "beginCaptures": {
                 "1": {
                     "name": "support.constant.handlebars"
@@ -510,12 +520,14 @@
                     "name": "variable.parameter.handlebars"
                 }
             }, 
+            "endCaptures": {
+                "1": {
+                    "name": "support.constant.handlebars"
+                }
+            },
             "patterns": [
                 {
-                    "include": "#string-single-quoted"
-                }, 
-                {
-                    "include": "#string-double-quoted"
+                    "include": "#string"
                 }
             ]
         }, 
@@ -523,17 +535,20 @@
             "begin": "\"", 
             "end": "\"", 
             "name": "string.quoted.double.handlebars", 
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.definition.string.end.html"
-                }
-            }, 
             "beginCaptures": {
                 "0": {
                     "name": "punctuation.definition.string.begin.html"
                 }
             }, 
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.html"
+                }
+            }, 
             "patterns": [
+                {
+                    "include": "#escaped-double-quote"
+                }, 
                 {
                     "include": "#block_comments"
                 }, 
@@ -627,10 +642,7 @@
             }, 
             "patterns": [
                 {
-                    "include": "#string-single-quoted"
-                }, 
-                {
-                    "include": "#string-double-quoted"
+                    "include": "#string"
                 }
             ], 
             "name": "entity.other.attribute-name.html", 
@@ -650,10 +662,7 @@
             "name": "meta.attribute-with-value.id.html", 
             "patterns": [
                 {
-                    "include": "#string-single-quoted"
-                }, 
-                {
-                    "include": "#string-double-quoted"
+                    "include": "#string"
                 }
             ]
         }, 
@@ -666,10 +675,7 @@
                     "include": "#tag_generic_attribute"
                 }, 
                 {
-                    "include": "#string-double-quoted"
-                }, 
-                {
-                    "include": "#string-single-quoted"
+                    "include": "#string"
                 }, 
                 {
                     "include": "#block_comments"

--- a/Handlebars.tmLanguage
+++ b/Handlebars.tmLanguage
@@ -146,11 +146,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#string-single-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-double-quoted</string>
+					<string>#string</string>
 				</dict>
 			</array>
 		</dict>
@@ -269,6 +265,20 @@
 				</dict>
 			</array>
 		</dict>
+		<key>escaped-double-quote</key>
+		<dict>
+			<key>match</key>
+			<string>\\"</string>
+			<key>name</key>
+			<string>constant.character.escape.js</string>
+		</dict>
+		<key>escaped-single-quote</key>
+		<dict>
+			<key>match</key>
+			<string>\\'</string>
+			<key>name</key>
+			<string>constant.character.escape.js</string>
+		</dict>
 		<key>html_tags</key>
 		<dict>
 			<key>patterns</key>
@@ -352,11 +362,7 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#string-double-quoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#string-single-quoted</string>
+							<string>#string</string>
 						</dict>
 					</array>
 				</dict>
@@ -849,6 +855,16 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#string</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
 					<string>#string-single-quoted</string>
 				</dict>
 				<dict>
@@ -883,6 +899,10 @@
 			<string>string.quoted.double.handlebars</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#escaped-double-quote</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#block_comments</string>
@@ -933,6 +953,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#escaped-single-quote</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#block_comments</string>
 				</dict>
 				<dict>
@@ -967,11 +991,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#string-double-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-single-quoted</string>
+					<string>#string</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1020,11 +1040,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#string-single-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-double-quoted</string>
+					<string>#string</string>
 				</dict>
 			</array>
 		</dict>
@@ -1053,11 +1069,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#string-single-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-double-quoted</string>
+					<string>#string</string>
 				</dict>
 			</array>
 		</dict>

--- a/test/template.handlebars
+++ b/test/template.handlebars
@@ -14,8 +14,10 @@
 {{log "Look at me!"}}
 
 {{! TODO: advanced helper parameters }}
-{{customHelper "test1" "test2" 32 true object.value}}
-{{{link "See more..." href=story.url class="story"}}}
+{{customHelper "test1" 'test2' 32 true object.value}}
+{{{link "See more..." href=story.url class="story" foo='bar'}}}
+{{customHelper 'test-single-quote-escaped\''}}
+{{customHelper "test-double-quote-escaped\""}}
 
 {{! TODO: array notation }}
 {{#each articles.[10].[#comments]}}


### PR DESCRIPTION
Recognize escaped single and double quote characters within their respective string types.

`'"'` was already recognized as a complete string, now so is `'\''`
`"'"` was already recognized as a complete string, now so is `"\""`

Unifies `#string-double-quoted` and `#string-single-quoted` includes under a common `#string` clause.

Adds more quoting examples to `template.handlebars`

Normalizes `beginCaptures`+`endCaptures` declaration order.

Classifies intra-string escaped quotes as `constant.character.escape.js` for syntax coloring.
