### PR TITLE
Allow hyphens in HTML tag names

### DIFF
--- a/Handlebars.JSON-tmLanguage
+++ b/Handlebars.JSON-tmLanguage
@@ -4,7 +4,7 @@
         "html_tags": {
             "patterns": [
                 {
-                    "begin": "(<)([a-zA-Z0-9:]+)(?=[^>]*></\\2>)", 
+                    "begin": "(<)([a-zA-Z0-9:-]+)(?=[^>]*></\\2>)", 
                     "beginCaptures": {
                         "1": {
                             "name": "punctuation.definition.tag.html"

--- a/Handlebars.tmLanguage
+++ b/Handlebars.tmLanguage
@@ -285,7 +285,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(&lt;)([a-zA-Z0-9:]+)(?=[^&gt;]*&gt;&lt;/\2&gt;)</string>
+					<string>(&lt;)([a-zA-Z0-9:-]+)(?=[^&gt;]*&gt;&lt;/\2&gt;)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Web Components spec requires at least one hyphen-minus character in
custom element names to considered to be valid.

http://www.w3.org/TR/custom-elements/#concepts
