### PR TITLE
Add 'x-tmpl-handlebars' to script type whitelist to catch migration from Mustache

### DIFF
--- a/grammars/Handlebars.json
+++ b/grammars/Handlebars.json
@@ -615,7 +615,7 @@
             ]
         },
         "inline_script": {
-            "begin": "(?:^\\s+)?(<)((?i:script))\\b(?:.*(type)=([\"'](?:text/x-handlebars-template|text/x-handlebars|text/template)[\"']))(?![^>]*/>)",
+            "begin": "(?:^\\s+)?(<)((?i:script))\\b(?:.*(type)=([\"'](?:text/x-handlebars-template|text/x-handlebars|text/template|x-tmpl-handlebars)[\"']))(?![^>]*/>)",
             "beginCaptures": {
                 "1": {
                     "name": "punctuation.definition.tag.html"

--- a/grammars/Handlebars.tmLanguage
+++ b/grammars/Handlebars.tmLanguage
@@ -805,7 +805,7 @@
 		<key>inline_script</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:^\s+)?(&lt;)((?i:script))\b(?:.*(type)=(["'](?:text/x-handlebars-template|text/x-handlebars|text/template)["']))(?![^&gt;]*/&gt;)</string>
+			<string>(?:^\s+)?(&lt;)((?i:script))\b(?:.*(type)=(["'](?:text/x-handlebars-template|text/x-handlebars|text/template|x-tmpl-handlebars)["']))(?![^&gt;]*/&gt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Mustache recommends using script type `x-tmpl-mustache` in their [documentation](https://github.com/janl/mustache.js#include-templates).

This PR adds `x-tmpl-handlebars` to the script type whitelist to catch migration from Mustache to Handlebars.

See issue #68 