### PR TITLE
Add suport for advanced helper parameters

### DIFF
--- a/grammars/Handlebars.json
+++ b/grammars/Handlebars.json
@@ -558,6 +558,27 @@
             "patterns": [
                 {
                     "include": "#string"
+                },
+                {
+                    "include": "#handlebars_attribute"
+                }
+            ]
+        },
+        "handlebars_attribute": {
+            "begin": "\\b([\\.a-zA-Z0-9_-]+)\\b\\s*(=)?",
+            "captures": {
+                "1": {
+                    "name": "variable.parameter.handlebars"
+                },
+                "2": {
+                    "name": "variable.parameter.handlebars"
+                }
+            },
+            "end": "(?='|\"|)",
+            "name": "entity.other.attribute-name.handlebars",
+            "patterns": [
+                {
+                    "include": "#string"
                 }
             ]
         },

--- a/grammars/Handlebars.tmLanguage
+++ b/grammars/Handlebars.tmLanguage
@@ -328,6 +328,35 @@
 			<key>name</key>
 			<string>constant.character.escape.js</string>
 		</dict>
+		<key>handlebars_attribute</key>
+		<dict>
+			<key>begin</key>
+			<string>\b([\.a-zA-Z0-9_-]+)\b\s*(=)?</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.handlebars</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.handlebars</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?='|"|)</string>
+			<key>name</key>
+			<string>entity.other.attribute-name.handlebars</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#string</string>
+				</dict>
+			</array>
+		</dict>
 		<key>html_tags</key>
 		<dict>
 			<key>patterns</key>
@@ -937,6 +966,10 @@
 				<dict>
 					<key>include</key>
 					<string>#string</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#handlebars_attribute</string>
 				</dict>
 			</array>
 		</dict>

--- a/test/template.handlebars
+++ b/test/template.handlebars
@@ -15,7 +15,7 @@
 {{!< GhostStyleExtend}}
 {{log "Look at me!"}}
 
-{{! TODO: advanced helper parameters }}
+{{! advanced helper parameters }}
 {{customHelper "test1" 'test2' 32 true object.value}}
 {{{link "See more..." href=story.url class="story" foo='bar'}}}
 {{customHelper 'test-single-quote-escaped\''}}


### PR DESCRIPTION
I've added basic support for advanced helper parameters.

I basically made them behave like HTML attributes, but fit them in with the Handlebars colors.